### PR TITLE
Fix export names

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bun run test
 SOLVED_DRILL_FILE=drills.csv OUTPUT_DIR=exported_drills bun export_drills.ts
 
 # Export solved puzzles to a TypeScript file as InputPuzzle[]
-SOLVED_PUZZLE_FILE=puzzles.csv MIN_DIFFICULTY=-20000 MAX_DIFFICULTY=-10000 MAX_EXPORT_PUZZLES=1000 bun export_puzzles.ts
+SOLVED_PUZZLE_FILE=puzzles.csv MIN_DIFFICULTY=-20000 MAX_DIFFICULTY=-10000 MAX_EXPORT_PUZZLES=1000 PUZZLES_ARRAY_NAME=puzzles bun export_puzzles.ts
 
 # Export one TypeScript file per difficulty range from DifficultyRanges.ts
 SOLVED_PUZZLE_FILE=puzzles.csv MAX_EXPORT_PUZZLES=500 OUTPUT_DIR=exported_puzzles_by_difficulty bun export_puzzles_by_difficulty.ts

--- a/export_drills.ts
+++ b/export_drills.ts
@@ -35,8 +35,9 @@ while ((drill = await feed.next()) !== null) {
 
 // Write drills to separate ts files per strategy
 for (const [strategy, puzzles] of drillsByStrategy.entries()) {
-  const arrayName: string = `${strategy}_drills`.toUpperCase();
-  const fileName: string = `${outputDir}/${arrayName}.ts`;
+  const fileBaseName: string = `${strategy}_drills`.toLowerCase();
+  const arrayName: string = fileBaseName.toUpperCase();
+  const fileName: string = `${outputDir}/${fileBaseName}.ts`;
   const content: string =
   `export const ${arrayName}: string[] = ${JSON.stringify(puzzles, null, 2)};\n`;
   await writeFile(fileName, content);

--- a/export_drills.ts
+++ b/export_drills.ts
@@ -35,7 +35,7 @@ while ((drill = await feed.next()) !== null) {
 
 // Write drills to separate ts files per strategy
 for (const [strategy, puzzles] of drillsByStrategy.entries()) {
-  const arrayName: string = `${strategy}_drills`;
+  const arrayName: string = `${strategy}_drills`.toUpperCase();
   const fileName: string = `${outputDir}/${arrayName}.ts`;
   const content: string =
   `export const ${arrayName}: string[] = ${JSON.stringify(puzzles, null, 2)};\n`;

--- a/export_puzzles.ts
+++ b/export_puzzles.ts
@@ -37,10 +37,6 @@ if (minDifficulty > maxDifficulty) {
   console.error(`MIN_DIFFICULTY (${minDifficulty}) cannot be greater than MAX_DIFFICULTY (${maxDifficulty}).`);
   process.exit(1);
 }
-if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(puzzlesArrayName)) {
-  console.error(`Invalid PUZZLES_ARRAY_NAME: '${puzzlesArrayName}'`);
-  process.exit(1);
-}
 
 const config = {
   "Solved Puzzle File": solvedPuzzleFile,

--- a/export_puzzles.ts
+++ b/export_puzzles.ts
@@ -8,6 +8,7 @@ import type { InputPuzzle } from "./puzzle.types";
 // Assign environment variables to variables with fallback defaults.
 const solvedPuzzleFile: string = process.env.SOLVED_PUZZLE_FILE ?? DEFAULT_SOLVED_PUZZLES_FILE;
 const BASE: number = 10;
+const puzzlesArrayName = process.env.PUZZLES_ARRAY_NAME ?? "puzzles";
 const minDifficultyEnv = process.env.MIN_DIFFICULTY;
 const maxDifficultyEnv = process.env.MAX_DIFFICULTY;
 const maxExportPuzzlesEnv = process.env.MAX_EXPORT_PUZZLES;
@@ -36,9 +37,14 @@ if (minDifficulty > maxDifficulty) {
   console.error(`MIN_DIFFICULTY (${minDifficulty}) cannot be greater than MAX_DIFFICULTY (${maxDifficulty}).`);
   process.exit(1);
 }
+if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(puzzlesArrayName)) {
+  console.error(`Invalid PUZZLES_ARRAY_NAME: '${puzzlesArrayName}'`);
+  process.exit(1);
+}
 
 const config = {
   "Solved Puzzle File": solvedPuzzleFile,
+  "Puzzles Array Name": puzzlesArrayName,
   "Min Difficulty": minDifficulty,
   "Max Difficulty": maxDifficulty,
   "Max Export Puzzles": Number.isFinite(maxExportPuzzles) ? maxExportPuzzles : "unbounded",
@@ -72,7 +78,7 @@ try {
 const fileName = "puzzles.ts";
 const content: string = `import type { InputPuzzle } from "./puzzle.types";
 
-export const puzzles: InputPuzzle[] = ${JSON.stringify(puzzles, null, 2)};
+export const ${puzzlesArrayName}: InputPuzzle[] = ${JSON.stringify(puzzles, null, 2)};
 `;
 await writeFile(fileName, content);
 log(`Wrote ${puzzles.length} puzzles to ${fileName}`);

--- a/export_puzzles_by_difficulty.ts
+++ b/export_puzzles_by_difficulty.ts
@@ -45,7 +45,7 @@ for (const range of DIFFICULTY_RANGES) {
     env: {
       ...process.env,
       SOLVED_PUZZLE_FILE: solvedPuzzleFile,
-      PUZZLES_ARRAY_NAME: `${range.name.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}_PUZZLES`,
+      PUZZLES_ARRAY_NAME: `${range.name.toUpperCase()}_PUZZLES`,
       MIN_DIFFICULTY: range.minDifficulty.toString(),
       MAX_DIFFICULTY: range.maxDifficulty.toString(),
       MAX_EXPORT_PUZZLES: maxExportPuzzles.toString(),

--- a/export_puzzles_by_difficulty.ts
+++ b/export_puzzles_by_difficulty.ts
@@ -45,6 +45,7 @@ for (const range of DIFFICULTY_RANGES) {
     env: {
       ...process.env,
       SOLVED_PUZZLE_FILE: solvedPuzzleFile,
+      PUZZLES_ARRAY_NAME: `${range.name.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}_PUZZLES`,
       MIN_DIFFICULTY: range.minDifficulty.toString(),
       MAX_DIFFICULTY: range.maxDifficulty.toString(),
       MAX_EXPORT_PUZZLES: maxExportPuzzles.toString(),

--- a/tests/test_export_drills.ts
+++ b/tests/test_export_drills.ts
@@ -30,14 +30,14 @@ export async function testExportDrills(): Promise<void> {
   await assertOutputContains(exportDrillsOutput, expectedConfigOutput, "export_drills.ts");
 
   // Verify an exported file contains expected drill puzzle string
-  const fileContent: string = await Bun.file(`${outputDir}/obvious_single_drills.ts`).text();
+  const fileContent: string = await Bun.file(`${outputDir}/OBVIOUS_SINGLE_DRILLS.ts`).text();
   await assertOutputContains(
     fileContent,
     [
-      "export const obvious_single_drills",
+      "export const OBVIOUS_SINGLE_DRILLS",
       "\"197568423852394167634172598763285914429716835581943276348629751915837642276451380\"",
     ],
-    `${outputDir}/obvious_single_drills.ts`
+    `${outputDir}/OBVIOUS_SINGLE_DRILLS.ts`
   );
 
   // Verify existing output directory causes early exit

--- a/tests/test_export_drills.ts
+++ b/tests/test_export_drills.ts
@@ -30,14 +30,14 @@ export async function testExportDrills(): Promise<void> {
   await assertOutputContains(exportDrillsOutput, expectedConfigOutput, "export_drills.ts");
 
   // Verify an exported file contains expected drill puzzle string
-  const fileContent: string = await Bun.file(`${outputDir}/OBVIOUS_SINGLE_DRILLS.ts`).text();
+  const fileContent: string = await Bun.file(`${outputDir}/obvious_single_drills.ts`).text();
   await assertOutputContains(
     fileContent,
     [
       "export const OBVIOUS_SINGLE_DRILLS",
       "\"197568423852394167634172598763285914429716835581943276348629751915837642276451380\"",
     ],
-    `${outputDir}/OBVIOUS_SINGLE_DRILLS.ts`
+    `${outputDir}/obvious_single_drills.ts`
   );
 
   // Verify existing output directory causes early exit

--- a/tests/test_export_puzzles.ts
+++ b/tests/test_export_puzzles.ts
@@ -5,6 +5,7 @@ export async function testExportPuzzles(): Promise<void> {
   const minDifficulty: string = "-16000";
   const maxDifficulty: string = "-15000";
   const maxExportPuzzles: string = "1";
+  const puzzlesArrayName: string = "testPuzzles";
 
   const exportPuzzlesRun = Bun.spawn({
     cmd: ["sh", "-c", "echo 'y' | bun export_puzzles.ts"],
@@ -14,6 +15,7 @@ export async function testExportPuzzles(): Promise<void> {
       MIN_DIFFICULTY: minDifficulty,
       MAX_DIFFICULTY: maxDifficulty,
       MAX_EXPORT_PUZZLES: maxExportPuzzles,
+      PUZZLES_ARRAY_NAME: puzzlesArrayName,
     },
     stdout: "pipe",
   });
@@ -26,6 +28,7 @@ export async function testExportPuzzles(): Promise<void> {
 
   const expectedConfigOutput: string[] = [
     `Solved Puzzle File: ${solvedPuzzleFile}`,
+    `Puzzles Array Name: ${puzzlesArrayName}`,
     `Min Difficulty: ${minDifficulty}`,
     `Max Difficulty: ${maxDifficulty}`,
     `Max Export Puzzles: ${maxExportPuzzles}`,
@@ -42,7 +45,7 @@ export async function testExportPuzzles(): Promise<void> {
     fileContent,
     [
       "import type { InputPuzzle } from \"./puzzle.types\";",
-      "export const puzzles: InputPuzzle[]",
+      `export const ${puzzlesArrayName}: InputPuzzle[]`,
       "\"p\": \"007500023850004060030102590700200010000710835080040076300620751915837042276000000\"",
       "\"s\": \"197568423852394167634172598763285914429716835581943276348629751915837642276451389\"",
       "\"d\": -15174",

--- a/tests/test_export_puzzles_by_difficulty.ts
+++ b/tests/test_export_puzzles_by_difficulty.ts
@@ -60,7 +60,7 @@ export async function testExportPuzzlesByDifficulty(): Promise<void> {
     noviceContent,
     [
       "import type { InputPuzzle } from \"./puzzle.types\";",
-      "export const puzzles: InputPuzzle[] =",
+      "export const NOVICE_PUZZLES: InputPuzzle[] =",
     ],
     `${outputDir}/novice_puzzles.ts`
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated exported identifiers for puzzles and drills to use uppercase naming conventions.
  * Export names are now configurable through environment variables instead of hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->